### PR TITLE
Added alpha and white point estimates to LischinskiTMO

### DIFF
--- a/include/tone_mapping.hpp
+++ b/include/tone_mapping.hpp
@@ -31,6 +31,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "tone_mapping/ward_histogram_tmo.hpp"
 #include "tone_mapping/segmentation_tmo_approx.hpp"
 #include "tone_mapping/durand_tmo.hpp"
+#include "tone_mapping/input_estimates.hpp"
 
 #endif /* PIC_TONE_MAPPING_HPP */
 

--- a/include/tone_mapping/input_estimates.hpp
+++ b/include/tone_mapping/input_estimates.hpp
@@ -1,0 +1,59 @@
+/*
+
+PICCANTE
+The hottest HDR imaging library!
+http://vcg.isti.cnr.it/piccante
+
+Copyright (C) 2014
+Visual Computing Laboratory - ISTI CNR
+http://vcg.isti.cnr.it
+First author: Francesco Banterle
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+*/
+
+#ifndef PIC_TONE_MAPPING_INPUT_ESTIMATES_HPP_
+#define PIC_TONE_MAPPING_INPUT_ESTIMATES_HPP_
+
+namespace pic {
+
+/**
+ * @brief EstimateAlpha
+ * @param LMax
+ * @param LMin
+ * @param logAverage
+ * @return
+ */
+inline float EstimateAlpha(float LMax, float LMin, float logAverage)
+{
+    float log2f       = logf(2.0f);
+    float log2Max     = logf(LMax      + 1e-9f) / log2f;
+    float log2Min     = logf(LMin      + 1e-9f) / log2f;
+    float log2Average = logf(logAverage + 1e-9f) / log2f;
+
+    float tmp = (2.0f * log2Average - log2Min - log2Max) / (log2Max - log2Min);
+
+    return 0.18f * powf(4.0f, tmp);
+}
+
+/**
+ * @brief EstimateWhitePoint
+ * @param LMax
+ * @param LMin
+ * @return
+ */
+inline float EstimateWhitePoint(float LMax, float LMin)
+{
+    float log2f       = logf(2.0f);
+    float log2Max     = logf(LMax + 1e-9f) / log2f;
+    float log2Min     = logf(LMin + 1e-9f) / log2f;
+
+    return 1.5f * powf(2.0f, (log2Max - log2Min - 5.0f));
+}
+
+} // end namespace pic
+
+#endif /* PIC_TONE_MAPPING_INPUT_ESTIMATES_HPP_ */

--- a/include/tone_mapping/lischinski_tmo.hpp
+++ b/include/tone_mapping/lischinski_tmo.hpp
@@ -21,6 +21,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #ifndef PIC_DISABLE_EIGEN
 
 #include "tone_mapping/lischinski_minimization.hpp"
+#include "tone_mapping/input_estimates.hpp"
 
 namespace pic {
 
@@ -31,8 +32,8 @@ namespace pic {
  * @param alpha
  * @return
  */
-Image *LischinskiTMO(Image *imgIn, Image *imgOut = NULL,
-                        float alpha = 0.5f)
+Image *LischinskiTMO(Image *imgIn, Image *imgOut = NULL, float alpha = -1.0f,
+        float whitePoint = -1.0f)
 {
     if(imgIn == NULL) {
         return NULL;
@@ -40,10 +41,6 @@ Image *LischinskiTMO(Image *imgIn, Image *imgOut = NULL,
 
     if(imgIn->channels != 3) {
         return NULL;
-    }
-
-    if(alpha <= 0.0f) {
-        alpha = 0.5f;
     }
 
     //extract luminance
@@ -58,6 +55,15 @@ Image *LischinskiTMO(Image *imgIn, Image *imgOut = NULL,
     float maxL_log = log2f(maxL);
     float minL_log = log2f(minL);
     float Lav = lum->getLogMeanVal()[0];
+
+    if(alpha <= 0.0f) {
+        alpha = EstimateAlpha(maxL, minL, Lav);
+    }
+
+    if(whitePoint <= 0.0f) {
+        whitePoint = EstimateWhitePoint(maxL, minL);
+    }
+    float whitePoint2 = whitePoint * whitePoint;
 
     int Z = int(ceilf(maxL_log - minL_log));
 
@@ -99,7 +105,7 @@ Image *LischinskiTMO(Image *imgIn, Image *imgOut = NULL,
 
             //photographic operator
             Rz[i] = Rz[i] * alpha / Lav;
-            float f = Rz[i] / (Rz[i] + 1.0f);
+            float f = (Rz[i] * (1 + Rz[i] / whitePoint2) ) / (Rz[i] + 1.0f);
             float tmp = f / Rz[i];
             fstop[i] = log2f(tmp);
         }

--- a/include/tone_mapping/reinhard_tmo.hpp
+++ b/include/tone_mapping/reinhard_tmo.hpp
@@ -23,6 +23,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "filtering/filter_bilateral_2ds.hpp"
 #include "filtering/filter_luminance.hpp"
 #include "filtering/filter_sigmoid_tmo.hpp"
+#include "tone_mapping/input_estimates.hpp"
 
 namespace pic {
 
@@ -44,42 +45,6 @@ inline float Sigmoid(float x)
 inline float SigmoidInv(float x)
 {
     return x / (1.0f - x);
-}
-
-/**
- * @brief EstimateAlpha
- * @param LMax
- * @param LMin
- * @param logAverage
- * @return
- */
-inline float EstimateAlpha(float LMax, float LMin, float logAverage)
-{
-
-    float log2f       = logf(2.0f);
-    float log2Max     = logf(LMax      + 1e-9f) / log2f;
-    float log2Min     = logf(LMin      + 1e-9f) / log2f;
-    float log2Average = logf(logAverage + 1e-9f) / log2f;
-
-    float tmp = (2.0f * log2Average - log2Min - log2Max) / (log2Max - log2Min);
-
-    return 0.18f * powf(4.0f, tmp);
-}
-
-/**
- * @brief EstimateWhitePoint
- * @param LMax
- * @param LMin
- * @return
- */
-inline float EstimateWhitePoint(float LMax, float LMin)
-{
-
-    float log2f       = logf(2.0f);
-    float log2Max     = logf(LMax + 1e-9f) / log2f;
-    float log2Min     = logf(LMin + 1e-9f) / log2f;
-
-    return 1.5f * powf(2.0f, (log2Max - log2Min - 5.0f));
 }
 
 /**

--- a/samples/tone_mapping/main.cpp
+++ b/samples/tone_mapping/main.cpp
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
         }
 
         printf("Tone mapping using Lischinski et al. 2006 automatic TMO...");
-        pic::Image *imgToneMapped_lischinski = pic::LischinskiTMO(&img, NULL, 0.5f);
+        pic::Image *imgToneMapped_lischinski = pic::LischinskiTMO(&img, NULL);
 
         /*pic::LT_NOR_GAMMA implies that when we save the image,
           this is quantized at 8-bit and gamma is applied.


### PR DESCRIPTION
This changes are meant to replicate the implementation in https://github.com/banterle/HDR_Toolbox/blob/master/source_code/Tmo/LischinskiTMO.m