### PR TITLE
removed malformed include

### DIFF
--- a/include/gl/filtering/filter_deform_grid.hpp
+++ b/include/gl/filtering/filter_deform_grid.hpp
@@ -19,7 +19,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #define PIC_GL_FILTERING_FILTER_DEFORM_GRID_HPP
 
 #include "util/gl/bicubic.hpp"
-#include "filtering/filter_DEFORM_GRID.hpp"
 #include "gl/filtering/filter.hpp"
 
 namespace pic {


### PR DESCRIPTION
File filter_DEFORM_GRID.hpp does not exists, and an include to the under lower case version would be recursive.