### PR TITLE
added multithreading flags for linux users with g++

### DIFF
--- a/samples/edge_aware_filtering/edge_aware_filtering.pro
+++ b/samples/edge_aware_filtering/edge_aware_filtering.pro
@@ -38,3 +38,8 @@ win32-msvc*{
 win32{
 	DEFINES += NOMINMAX
 }
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/exposure_fusion/exposure_fusion.pro
+++ b/samples/exposure_fusion/exposure_fusion.pro
@@ -38,3 +38,8 @@ win32-msvc*{
 win32{
 	DEFINES += NOMINMAX
 }
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/fft/main_fft.pro
+++ b/samples/fft/main_fft.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/hdr_generation/hdr_generation.pro
+++ b/samples/hdr_generation/hdr_generation.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/hdr_generation_alignment/hdr_generation_alignment.pro
+++ b/samples/hdr_generation_alignment/hdr_generation_alignment.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/metrics_test/metrics_test.pro
+++ b/samples/metrics_test/metrics_test.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/opengl_deform_grid/opengl_deform_grid.pro
+++ b/samples/opengl_deform_grid/opengl_deform_grid.pro
@@ -26,3 +26,8 @@ win32{
 }
 
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/opengl_exposure_fusion/opengl_exposure_fusion.pro
+++ b/samples/opengl_exposure_fusion/opengl_exposure_fusion.pro
@@ -28,3 +28,8 @@ win32{
 unix{
     SOURCES += ../opengl_common_code/gl_core_4_0.c
 }
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/opengl_filtering/opengl_filtering.pro
+++ b/samples/opengl_filtering/opengl_filtering.pro
@@ -26,3 +26,8 @@ win32{
 }
 
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/opengl_image_transform/opengl_image_transform.pro
+++ b/samples/opengl_image_transform/opengl_image_transform.pro
@@ -26,3 +26,8 @@ win32{
 }
 
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/opengl_operators/opengl_operators.pro
+++ b/samples/opengl_operators/opengl_operators.pro
@@ -26,3 +26,8 @@ win32{
 }
 
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/opengl_push_pull/opengl_push_pull.pro
+++ b/samples/opengl_push_pull/opengl_push_pull.pro
@@ -26,3 +26,8 @@ win32{
 }
 
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/opengl_simple_io/opengl_simple_io.pro
+++ b/samples/opengl_simple_io/opengl_simple_io.pro
@@ -26,3 +26,8 @@ win32{
 }
 
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/opengl_tone_mapping/opengl_tone_mapping.pro
+++ b/samples/opengl_tone_mapping/opengl_tone_mapping.pro
@@ -26,3 +26,8 @@ win32{
 }
 
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/remove_nuked/remove_nuked.pro
+++ b/samples/remove_nuked/remove_nuked.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_augmented_reality/simple_augmented_reality.pro
+++ b/samples/simple_augmented_reality/simple_augmented_reality.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_connected_components/simple_connected_components.pro
+++ b/samples/simple_connected_components/simple_connected_components.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_corners_extraction/corners_extraction.pro
+++ b/samples/simple_corners_extraction/corners_extraction.pro
@@ -38,3 +38,8 @@ win32-msvc*{
 win32{
 	DEFINES += NOMINMAX
 }
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_dct_decomposition/simple_dct_decomposition.pro
+++ b/samples/simple_dct_decomposition/simple_dct_decomposition.pro
@@ -38,3 +38,8 @@ win32-msvc*{
 win32{
 	DEFINES += NOMINMAX
 }
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_debayering/simple_debayering.pro
+++ b/samples/simple_debayering/simple_debayering.pro
@@ -39,3 +39,8 @@ win32{
         DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_deblurring/simple_deblurring.pro
+++ b/samples/simple_deblurring/simple_deblurring.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_deform_grid/simple_deform_grid.pro
+++ b/samples/simple_deform_grid/simple_deform_grid.pro
@@ -40,3 +40,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_filtering/simple_filtering.pro
+++ b/samples/simple_filtering/simple_filtering.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_gray_scale/simple_gray_scale.pro
+++ b/samples/simple_gray_scale/simple_gray_scale.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_grow_cut/simple_grow_cut.pro
+++ b/samples/simple_grow_cut/simple_grow_cut.pro
@@ -39,3 +39,8 @@ win32{
         DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_histogram_matching/simple_histogram_matching.pro
+++ b/samples/simple_histogram_matching/simple_histogram_matching.pro
@@ -38,3 +38,8 @@ win32-msvc*{
 win32{
 	DEFINES += NOMINMAX
 }
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_image_transform/simple_image_transform.pro
+++ b/samples/simple_image_transform/simple_image_transform.pro
@@ -38,3 +38,8 @@ win32-msvc*{
 win32{
 	DEFINES += NOMINMAX
 }
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_io/simple_io.pro
+++ b/samples/simple_io/simple_io.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_k_means_2D/kmeans.pro
+++ b/samples/simple_k_means_2D/kmeans.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_laplacian_blending/simple_laplacian_blending.pro
+++ b/samples/simple_laplacian_blending/simple_laplacian_blending.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_matching/simple_matching.pro
+++ b/samples/simple_matching/simple_matching.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_poisson_blending/simple_poisson_blending.pro
+++ b/samples/simple_poisson_blending/simple_poisson_blending.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_push_pull/push_pull.pro
+++ b/samples/simple_push_pull/push_pull.pro
@@ -38,3 +38,8 @@ win32-msvc*{
 win32{
 	DEFINES += NOMINMAX
 }
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_qt/simple_qt.pro
+++ b/samples/simple_qt/simple_qt.pro
@@ -42,3 +42,8 @@ win32-msvc*{
 win32{
 	DEFINES += NOMINMAX
 }
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_tone_mapping/simple_tone_mapping.pro
+++ b/samples/simple_tone_mapping/simple_tone_mapping.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_triangulation/simple_triangulation.pro
+++ b/samples/simple_triangulation/simple_triangulation.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/simple_up_and_down_sampling/simple_up_and_down_sampling.pro
+++ b/samples/simple_up_and_down_sampling/simple_up_and_down_sampling.pro
@@ -38,3 +38,8 @@ win32-msvc*{
 win32{
 	DEFINES += NOMINMAX
 }
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/super_pixels/main_super_pixels.pro
+++ b/samples/super_pixels/main_super_pixels.pro
@@ -39,3 +39,8 @@ win32{
 	DEFINES += NOMINMAX
 }
 
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}

--- a/samples/tone_mapping/tone_mapping.pro
+++ b/samples/tone_mapping/tone_mapping.pro
@@ -38,3 +38,8 @@ win32-msvc*{
 win32{
 	DEFINES += NOMINMAX
 }
+
+linux-g++*{
+    QMAKE_CXXFLAGS += -fopenmp -pthread
+    QMAKE_LFLAGS += -fopenmp
+}


### PR DESCRIPTION
Importing any project on Ubuntu 14.04 in Qtcreator produces an insane amount of warnings about OpenMP parallel pragmas. Added the necessary flags to compile by default with support for it on linux with g++.