### PR TITLE
Added PIC_INLINE in some functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ HOW TO INSTALL:
 
 3) Include "piccante.hpp" in your project
 
+
+NOTE ON CODE USE:
+=================
+When you use parts or the full source code of this project in your own project, please remember to cite this project both in your project webpage and in its source code. This SHOULD be done even when you convert this code into another programming language.
+
+Be kind.
+
 NOTE ON PULL REQUESTS:
 =====================
 Please, send your pull requests to the develop branch.

--- a/examples/filtering_edge_aware/main.cpp
+++ b/examples/filtering_edge_aware/main.cpp
@@ -118,25 +118,6 @@ int main(int argc, char *argv[])
             printf("Writing had some issues!\n");
         }
 
-        //the non-local means filter
-        printf("Filtering the image with Non-Local Means filter;\n");
-
-        pic::FilterNonLocalMeansF fltNLM(31, 5, 0.05f);
-        output = fltNLM.Process(input, output);
-
-        printf("Ok!\n");
-
-        printf("Writing the file to disk...");
-
-        bWritten = output->Write("../data/output/" + name + "_filtered_non_local_means.png", pic::LT_NOR_GAMMA);
-
-        if(bWritten) {
-            printf("Ok\n");
-        } else {
-            printf("Writing had some issues!\n");
-        }
-
-
         //the Anisotropic Diffusion
         printf("Filtering the image with the Anisotropic Diffusion;\n");
         printf("this has sigma_s = 4.0 and sigma_r = 0.05 ... ");

--- a/include/colors/matrix_from_primaries.hpp
+++ b/include/colors/matrix_from_primaries.hpp
@@ -41,7 +41,7 @@ namespace pic {
  * @param white_point_XYZ is the XYZ values of the white point primary
  * @return It returns a 3x3 matrix for converting XYZ values into the defined color space
  */
-float *createMatrixFromPrimaries(float *red_XYZ,
+PIC_INLINE float *createMatrixFromPrimaries(float *red_XYZ,
                                  float *green_XYZ,
                                  float *blue_XYZ,
                                  float *white_point_XYZ,

--- a/include/computer_vision/image_alignment.hpp
+++ b/include/computer_vision/image_alignment.hpp
@@ -47,7 +47,7 @@ namespace pic {
  * @param img1
  * @return
  */
-Eigen::Matrix3d getHomographyMatrixFromTwoImage(Image *img0, Image *img1)
+PIC_INLINE Eigen::Matrix3d getHomographyMatrixFromTwoImage(Image *img0, Image *img1)
 {
     //output corners
     std::vector< Eigen::Vector2f > corners_from_img0;
@@ -92,7 +92,7 @@ Eigen::Matrix3d getHomographyMatrixFromTwoImage(Image *img0, Image *img1)
  * @param imgOut
  * @return
  */
-Image* imageAlignmentWithORB(Image *img0, Image *img1, Image *imgOut)
+PIC_INLINE Image* imageAlignmentWithORB(Image *img0, Image *img1, Image *imgOut)
 {
     auto H = getHomographyMatrixFromTwoImage(img0, img1);
 

--- a/include/externals/tinyexr/tinyexr.h
+++ b/include/externals/tinyexr/tinyexr.h
@@ -707,7 +707,7 @@ const char *mz_version(void);
 //  MZ_STREAM_ERROR if the stream is bogus.
 //  MZ_PARAM_ERROR if the input parameters are bogus.
 //  MZ_MEM_ERROR on out of memory.
-int mz_deflateInit(mz_streamp pStream, int level);
+PIC_INLINE int mz_deflateInit(mz_streamp pStream, int level);
 
 // mz_deflateInit2() is like mz_deflate(), except with more control:
 // Additional parameters:
@@ -716,7 +716,7 @@ int mz_deflateInit(mz_streamp pStream, int level);
 //   zlib header/adler-32 footer) or -MZ_DEFAULT_WINDOW_BITS (raw deflate/no
 //   header or footer)
 //   mem_level must be between [1, 9] (it's checked but ignored by miniz.c)
-int mz_deflateInit2(mz_streamp pStream, int level, int method, int window_bits,
+PIC_INLINE int mz_deflateInit2(mz_streamp pStream, int level, int method, int window_bits,
                     int mem_level, int strategy);
 
 // Quickly resets a compressor without having to reallocate anything. Same as
@@ -741,7 +741,7 @@ int mz_deflateReset(mz_streamp pStream);
 //   MZ_BUF_ERROR if no forward progress is possible because the input and/or
 //   output buffers are empty. (Fill up the input buffer or free up some output
 //   space and try again.)
-int mz_deflate(mz_streamp pStream, int flush);
+PIC_INLINE int mz_deflate(mz_streamp pStream, int flush);
 
 // mz_deflateEnd() deinitializes a compressor:
 // Return values:
@@ -1525,7 +1525,7 @@ inline tdefl_status tdefl_compress_buffer(tdefl_compressor *d, const void *pIn_b
                                    size_t in_buf_size, tdefl_flush flush);
 
 inline tdefl_status tdefl_get_prev_return_status(tdefl_compressor *d);
-inline mz_uint32 tdefl_get_adler32(tdefl_compressor *d);
+PIC_INLINE  mz_uint32 tdefl_get_adler32(tdefl_compressor *d);
 
 // Can't use tdefl_create_comp_flags_from_zip_params if MINIZ_NO_ZLIB_APIS isn't
 // defined, because it uses some of its macros.
@@ -6894,7 +6894,7 @@ FP16 float_to_half_full(FP32 f) {
 // #define IMF_B44_COMPRESSION 6
 // #define IMF_B44A_COMPRESSION  7
 
-const char *ReadString(std::string &s, const char *ptr) {
+PIC_INLINE const char *ReadString(std::string &s, const char *ptr) {
   // Read untile NULL(\0).
   const char *p = ptr;
   const char *q = ptr;
@@ -6906,7 +6906,7 @@ const char *ReadString(std::string &s, const char *ptr) {
   return q + 1; // skip '\0'
 }
 
-const char *ReadAttribute(std::string &name, std::string &ty,
+PIC_INLINE const char *ReadAttribute(std::string &name, std::string &ty,
                           std::vector<unsigned char> &data, const char *ptr) {
 
   if ((*ptr) == 0) {
@@ -6933,7 +6933,7 @@ const char *ReadAttribute(std::string &name, std::string &ty,
   return p;
 }
 
-void WriteAttribute(FILE *fp, const char *name, const char *type,
+PIC_INLINE void WriteAttribute(FILE *fp, const char *name, const char *type,
                     const unsigned char *data, int len) {
   size_t n = fwrite(name, 1, strlen(name) + 1, fp);
   assert(n == strlen(name) + 1);
@@ -6954,7 +6954,7 @@ void WriteAttribute(FILE *fp, const char *name, const char *type,
   (void)n;
 }
 
-void WriteAttributeToMemory(std::vector<unsigned char> &out, const char *name,
+PIC_INLINE void WriteAttributeToMemory(std::vector<unsigned char> &out, const char *name,
                             const char *type, const unsigned char *data,
                             int len) {
   out.insert(out.end(), name, name + strlen(name) + 1);
@@ -6977,7 +6977,7 @@ typedef struct {
   int ySampling;
 } ChannelInfo;
 
-void ReadChannelInfo(std::vector<ChannelInfo> &channels,
+PIC_INLINE void ReadChannelInfo(std::vector<ChannelInfo> &channels,
                      const std::vector<unsigned char> &data) {
   const char *p = reinterpret_cast<const char *>(&data.at(0));
 
@@ -7007,7 +7007,7 @@ void ReadChannelInfo(std::vector<ChannelInfo> &channels,
   }
 }
 
-void WriteChannelInfo(std::vector<unsigned char> &data,
+PIC_INLINE void WriteChannelInfo(std::vector<unsigned char> &data,
                       const std::vector<ChannelInfo> &channels) {
 
   size_t sz = 0;
@@ -7052,7 +7052,7 @@ void WriteChannelInfo(std::vector<unsigned char> &data,
   (*p) = '\0';
 }
 
-void CompressZip(unsigned char *dst, unsigned long long &compressedSize,
+PIC_INLINE void CompressZip(unsigned char *dst, unsigned long long &compressedSize,
                  const unsigned char *src, unsigned long srcSize) {
 
   std::vector<unsigned char> tmpBuf(srcSize);
@@ -7114,7 +7114,7 @@ void CompressZip(unsigned char *dst, unsigned long long &compressedSize,
   compressedSize = outSize;
 }
 
-void DecompressZip(unsigned char *dst, unsigned long &uncompressedSize,
+PIC_INLINE void DecompressZip(unsigned char *dst, unsigned long &uncompressedSize,
                    const unsigned char *src, unsigned long srcSize) {
   std::vector<unsigned char> tmpBuf(uncompressedSize);
 
@@ -7269,7 +7269,7 @@ inline void wdec16(unsigned short l, unsigned short h, unsigned short &a,
 //
 
 #if 0 // @todo
-void wav2Encode(unsigned short *in, // io: values are transformed in place
+PIC_INLINE void wav2Encode(unsigned short *in, // io: values are transformed in place
                 int nx,             // i : x size
                 int ox,             // i : x offset
                 int ny,             // i : y size
@@ -7378,7 +7378,7 @@ void wav2Encode(unsigned short *in, // io: values are transformed in place
 // 2D Wavelet decoding:
 //
 
-void wav2Decode(unsigned short *in, // io: values are transformed in place
+PIC_INLINE void wav2Decode(unsigned short *in, // io: values are transformed in place
                 int nx,             // i : x size
                 int ox,             // i : x offset
                 int ny,             // i : y size
@@ -7518,7 +7518,6 @@ struct HufDec { // short code		long code
   int lit : 24; // lit			p size
   int *p;       // 0			lits
 };
-
 inline long long hufLength(long long code) { return code & 63; }
 
 inline long long hufCode(long long code) { return code >> 6; }

--- a/include/filtering/filter_bilateral_2df.hpp
+++ b/include/filtering/filter_bilateral_2df.hpp
@@ -106,7 +106,7 @@ PIC_INLINE FilterBilateral2DF::FilterBilateral2DF(float sigma_s, float sigma_r) 
     pg = new PrecomputedGaussian(sigma_s);
 }
 
-FilterBilateral2DF::~FilterBilateral2DF()
+PIC_INLINE FilterBilateral2DF::~FilterBilateral2DF()
 {
     pg = delete_s(pg);
 }

--- a/include/gl/filtering/filter_bilateral_2ds_e.hpp
+++ b/include/gl/filtering/filter_bilateral_2ds_e.hpp
@@ -169,7 +169,7 @@ public:
 
 };
 
-FilterGLBilateral2DSE::FilterGLBilateral2DSE(float sigma_s, float sigma_p, float sigma_n, float sigma_a): FilterGL()
+PIC_INLINE FilterGLBilateral2DSE::FilterGLBilateral2DSE(float sigma_s, float sigma_p, float sigma_n, float sigma_a): FilterGL()
 {
     //protected values are assigned/computed
     this->sigma_s = sigma_s;
@@ -208,7 +208,7 @@ FilterGLBilateral2DSE::FilterGLBilateral2DSE(float sigma_s, float sigma_p, float
     initShaders();
 }
 
-FilterGLBilateral2DSE::~FilterGLBilateral2DSE()
+PIC_INLINE FilterGLBilateral2DSE::~FilterGLBilateral2DSE()
 {
     delete imageRand;
     delete ms;
@@ -216,7 +216,7 @@ FilterGLBilateral2DSE::~FilterGLBilateral2DSE()
     //free shader etc...
 }
 
-void FilterGLBilateral2DSE::FragmentShader()
+PIC_INLINE void FilterGLBilateral2DSE::FragmentShader()
 {
     fragment_source = MAKE_STRING(
     uniform sampler2D	u_tex;
@@ -273,7 +273,7 @@ void FilterGLBilateral2DSE::FragmentShader()
 
 }
 
-void FilterGLBilateral2DSE::initShaders()
+PIC_INLINE void FilterGLBilateral2DSE::initShaders()
 {
 #ifdef PIC_DEBUG
     printf("Number of samples: %d\n", ms->nSamples);
@@ -284,7 +284,7 @@ void FilterGLBilateral2DSE::initShaders()
     update(-1.0f, -1.0f, -1.0f, -1.0f);
 }
 
-void FilterGLBilateral2DSE::update(float sigma_s, float sigma_p, float sigma_n, float sigma_a)
+PIC_INLINE void FilterGLBilateral2DSE::update(float sigma_s, float sigma_p, float sigma_n, float sigma_a)
 {
 
     bool flag = false;
@@ -342,7 +342,7 @@ void FilterGLBilateral2DSE::update(float sigma_s, float sigma_p, float sigma_n, 
     technique.unbind();
 }
 
-ImageGL *FilterGLBilateral2DSE::Process(ImageGLVec imgIn,
+PIC_INLINE ImageGL *FilterGLBilateral2DSE::Process(ImageGLVec imgIn,
         ImageGL *imgOut)
 {
     if(imgIn[0] == NULL) {

--- a/include/gl/filtering/filter_disp.hpp
+++ b/include/gl/filtering/filter_disp.hpp
@@ -87,7 +87,7 @@ public:
     }
 };
 
-FilterGLDisp::FilterGLDisp(): FilterGL()
+PIC_INLINE FilterGLDisp::FilterGLDisp(): FilterGL()
 {
     sigma = 2.0f;
     sigma_s = 2.0f;
@@ -95,7 +95,7 @@ FilterGLDisp::FilterGLDisp(): FilterGL()
     initShaders();
 }
 
-void FilterGLDisp::initShaders()
+PIC_INLINE void FilterGLDisp::initShaders()
 {
     fragment_source = MAKE_STRING
                       (
@@ -203,7 +203,7 @@ void FilterGLDisp::initShaders()
     technique.unbind();
 }
 
-void FilterGLDisp::update(float sigma, float sigma_s, float sigma_r, bool bUse,
+PIC_INLINE void FilterGLDisp::update(float sigma, float sigma_s, float sigma_r, bool bUse,
                           bool bLeft)
 {
     this->sigma = sigma;

--- a/include/gl/filtering/filter_gaussian_1d.hpp
+++ b/include/gl/filtering/filter_gaussian_1d.hpp
@@ -91,7 +91,7 @@ public:
     }
 };
 
-FilterGLGaussian1D::FilterGLGaussian1D(float sigma, int direction = 0,
+PIC_INLINE FilterGLGaussian1D::FilterGLGaussian1D(float sigma, int direction = 0,
                                        GLenum target = GL_TEXTURE_2D): FilterGLConv1D(NULL, direction, target)
 {
     pg = NULL;
@@ -101,12 +101,12 @@ FilterGLGaussian1D::FilterGLGaussian1D(float sigma, int direction = 0,
     update(sigma);
 }
 
-FilterGLGaussian1D::~FilterGLGaussian1D()
+PIC_INLINE FilterGLGaussian1D::~FilterGLGaussian1D()
 {
     release();
 }
 
-void FilterGLGaussian1D::update(float sigma)
+PIC_INLINE void FilterGLGaussian1D::update(float sigma)
 {
     bool bChanges = false;
 

--- a/include/image.hpp
+++ b/include/image.hpp
@@ -1410,7 +1410,7 @@ PIC_INLINE float *Image::getMaxVal(BBox *box = NULL, float *ret = NULL)
     }
 
     if(box == NULL) {
-        box = new BBox(width, height, frames);
+        box = &fullBox;
     }
 
     if(ret == NULL) {
@@ -1443,7 +1443,7 @@ PIC_INLINE float *Image::getMinVal(BBox *box = NULL, float *ret = NULL)
     }
 
     if(box == NULL) {
-        box = new BBox(width, height, frames);
+        box = &fullBox;
     }
 
     if(ret == NULL) {

--- a/include/io/exif.hpp
+++ b/include/io/exif.hpp
@@ -33,7 +33,7 @@ namespace pic {
  * @param bMotorola
  * @return
  */
-unsigned int twoByteToValue(unsigned char data[2], bool bMotorola)
+PIC_INLINE unsigned int twoByteToValue(unsigned char data[2], bool bMotorola)
 {
     if(bMotorola) {
         return  (data[0] << 8) + (data[1]);
@@ -48,7 +48,7 @@ unsigned int twoByteToValue(unsigned char data[2], bool bMotorola)
  * @param bMotorola
  * @return
  */
-unsigned int fourByteToValue(unsigned char data[4], bool bMotorola)
+PIC_INLINE unsigned int fourByteToValue(unsigned char data[4], bool bMotorola)
 {
     if(bMotorola) {
         return (data[0] << 24) + (data[1] << 16) +
@@ -66,7 +66,7 @@ unsigned int fourByteToValue(unsigned char data[4], bool bMotorola)
  * @param bMotorola
  * @return
  */
-bool checkTag(unsigned char tag[2], unsigned short tag_r, bool bMotorola)
+PIC_INLINE bool checkTag(unsigned char tag[2], unsigned short tag_r, bool bMotorola)
 {
     unsigned char tag_ref[2];
     tag_ref[0] = (tag_r >> 8) & 0x00ff;
@@ -88,7 +88,7 @@ bool checkTag(unsigned char tag[2], unsigned short tag_r, bool bMotorola)
  * @param bMotorola
  * @return
  */
-int getTagID(unsigned char tag[2], bool bMotorola)
+PIC_INLINE int getTagID(unsigned char tag[2], bool bMotorola)
 {
     if(checkTag(tag, 0x829a, bMotorola)) {
         return 0;
@@ -118,7 +118,7 @@ int getTagID(unsigned char tag[2], bool bMotorola)
  * @param value
  * @return
  */
-int getBytesForComponents(int value)
+PIC_INLINE int getBytesForComponents(int value)
 {
     switch(value)
     {
@@ -183,7 +183,7 @@ int getBytesForComponents(int value)
  * @param length
  * @return
  */
-std::string readString(FILE *file, int length)
+PIC_INLINE std::string readString(FILE *file, int length)
 {
     char *tmp = new char[length];
     fread(tmp, 1, length, file);
@@ -199,7 +199,7 @@ std::string readString(FILE *file, int length)
  * @param data
  * @return
  */
-std::string readStringFromUChar(unsigned char *data, int length)
+PIC_INLINE std::string readStringFromUChar(unsigned char *data, int length)
 {
     std::string str;
 
@@ -216,7 +216,7 @@ std::string readStringFromUChar(unsigned char *data, int length)
  * @param bMotorola
  * @return
  */
-float readUnsignedRational(FILE *file, bool bMotorola)
+PIC_INLINE float readUnsignedRational(FILE *file, bool bMotorola)
 {
     unsigned char val0[4];
     fread(val0, 1, 4, file);
@@ -247,7 +247,7 @@ struct EXIFInfo
  * @param info
  * @return
  */
-bool readEXIF(std::string name, EXIFInfo &info)
+PIC_INLINE bool readEXIF(std::string name, EXIFInfo &info)
 {
         FILE *file = fopen(name.c_str(), "rb");
 

--- a/include/metrics/base.hpp
+++ b/include/metrics/base.hpp
@@ -35,7 +35,7 @@ enum METRICS_DOMAIN{MD_LIN, MD_LOG10, MD_PU};
  * @param type
  * @return
  */
-float changeDomain(float x, METRICS_DOMAIN type = MD_LIN)
+PIC_INLINE float changeDomain(float x, METRICS_DOMAIN type = MD_LIN)
 {
     switch(type){
     case MD_LIN: {

--- a/include/metrics/pu_encode.hpp
+++ b/include/metrics/pu_encode.hpp
@@ -34,7 +34,7 @@ namespace pic {
  * in the range [10^-6, 10^10] cd/m^2
  * @return it returns a perceptually uniform value
  */
-float PUEncode(float L)
+PIC_INLINE float PUEncode(float L)
 {
     return Arrayf::interp(C_PU_x, C_PU_y, 256, log10f(L + 1e-7f));
 }
@@ -44,7 +44,7 @@ float PUEncode(float L)
  * @param p is a perceptually uniform luminance value
  * @return it returns a luminance value in the range [10^-6, 10^10] cd/m^2
  */
-float PUDecode(float p)
+PIC_INLINE float PUDecode(float p)
 {
     return powf(10.0f, Arrayf::interp(C_PU_y, C_PU_x, 256, p));
 }

--- a/include/metrics/pu_encode_data.hpp
+++ b/include/metrics/pu_encode_data.hpp
@@ -26,7 +26,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 namespace pic {
 
-float C_PU_x[256] = {
+PIC_INLINE float C_PU_x[256] = {
     -5.000000f,
     -4.882784f,
     -4.765568f,
@@ -285,7 +285,7 @@ float C_PU_x[256] = {
     10.000000f
 };
 
-float C_PU_y[256] = {
+PIC_INLINE float C_PU_y[256] = {
     0.000000f,
     0.025875f,
     0.055091f,

--- a/include/util/gl/buffer_ops.hpp
+++ b/include/util/gl/buffer_ops.hpp
@@ -101,11 +101,11 @@ private:
 
 };
 
-std::mutex BufferOpsGL::mutex;
+PIC_INLINE std::mutex BufferOpsGL::mutex;
 
-std::map<std::thread::id, bool> BufferOpsGL::flag;
+PIC_INLINE std::map<std::thread::id, bool> BufferOpsGL::flag;
 
-std::map<std::thread::id, BufferOpsGL*> BufferOpsGL::buffer_ops_gl;
+PIC_INLINE std::map<std::thread::id, BufferOpsGL*> BufferOpsGL::buffer_ops_gl;
 
 } // end namespace pic
 

--- a/include/util/gl/redux_ops.hpp
+++ b/include/util/gl/redux_ops.hpp
@@ -82,11 +82,11 @@ private:
 
 };
 
-std::mutex ReduxOpsGL::mutex;
+PIC_INLINE std::mutex ReduxOpsGL::mutex;
 
-std::map<std::thread::id, bool> ReduxOpsGL::flag;
+PIC_INLINE std::map<std::thread::id, bool> ReduxOpsGL::flag;
 
-std::map<std::thread::id, ReduxOpsGL*> ReduxOpsGL::redux_ops_gl;
+PIC_INLINE std::map<std::thread::id, ReduxOpsGL*> ReduxOpsGL::redux_ops_gl;
 
 } // end namespace pic
 

--- a/include/util/math.hpp
+++ b/include/util/math.hpp
@@ -475,7 +475,7 @@ PIC_INLINE float normalDistribution(float x, float mu = 0.0f, float sigma = 1.0f
  * @param sigma
  * @return
  */
-float normalCDF(float x, float mu, float sigma)
+PIC_INLINE float normalCDF(float x, float mu, float sigma)
 {
     float t = (x - mu) / (sigma * C_SQRT_2);
     return (1.0f + std::erf(t)) * 0.5f;

--- a/include/util/string.hpp
+++ b/include/util/string.hpp
@@ -479,7 +479,7 @@ inline std::string checkPath(std::string name)
  * @param pathFolder
  * @return
  */
-std::string adjustPath(std::string nameFile, std::string pathFolder)
+PIC_INLINE std::string adjustPath(std::string nameFile, std::string pathFolder)
 {
     if(!checkAbsolutePath(nameFile)) {
         std::string fullPath = checkPath(nameFile);


### PR DESCRIPTION
When trying to compile the binding with pybind11, during the linking phase the compiler gives a lot of errors regarding "C++ One Definition rule violated". Since Piccante is a header-only library, when trying to compile multiple src files for the binding (I have one src file for every binded class), every resulting object file would have the functions with the missing PIC_INLINE declared. When merging all the objects together, the linker finds these multiple definitions and gives the "C++ One Definition rule violated" error.