### PR TITLE
Fixed the two functions with a typo in their name.

### DIFF
--- a/include/algorithms/camera_response_function.hpp
+++ b/include/algorithms/camera_response_function.hpp
@@ -421,7 +421,7 @@ public:
 
         //log domain exposure time        
         std::vector< float > log_exposures;
-        ImaveVecGetExposureTimesAsArray(stack, log_exposures, true);
+        ImageVecGetExposureTimesAsArray(stack, log_exposures, true);
 
         #ifdef PIC_DEBUG
             printf("nSamples: %d\n", nSamples);
@@ -482,7 +482,7 @@ public:
         std::size_t nExposures = stack.size();
 
         std::vector< float > exposures;
-        ImaveVecGetExposureTimesAsArray(stack, exposures, false);
+        ImageVecGetExposureTimesAsArray(stack, exposures, false);
 
         int stride = nSamples * int(nExposures);
 

--- a/include/algorithms/camera_response_function.hpp
+++ b/include/algorithms/camera_response_function.hpp
@@ -465,7 +465,7 @@ public:
         type_linearization = IL_POLYNOMIAL;
 
         //sort the array by exposure
-        ImaveVecSortByExposureTime(stack);
+        ImageVecSortByExposureTime(stack);
 
         //subsample the image stack
         stackOut.execute(stack, nSamples, alpha);

--- a/include/algorithms/hdr_merger.hpp
+++ b/include/algorithms/hdr_merger.hpp
@@ -152,7 +152,7 @@ public:
 
         //align images
         if(hdra != HA_NONE && (n > 1)) {
-            ImaveVecSortByExposureTime(stack);
+            ImageVecSortByExposureTime(stack);
 
             if(hdra == HA_MTB) {
                 std::vector<Vec2i> shifts;

--- a/include/image_vec.hpp
+++ b/include/image_vec.hpp
@@ -90,10 +90,10 @@ PIC_INLINE ImageVec Quad(Image *img1, Image *img2, Image *img3,
 }
 
 /**
- * @brief ImaveVecSortByExposureTime
+ * @brief ImageVecSortByExposureTime
  * @param stack
  */
-PIC_INLINE void ImaveVecSortByExposureTime(ImageVec &stack)
+PIC_INLINE void ImageVecSortByExposureTime(ImageVec &stack)
 {
     std::sort(stack.begin(), stack.end(), [](const Image *l, const Image *r)->bool{
         if (!l || !r) {
@@ -105,10 +105,10 @@ PIC_INLINE void ImaveVecSortByExposureTime(ImageVec &stack)
 
 
 /**
- * @brief ImaveVecGetExposureTimesAsArray
+ * @brief ImageVecGetExposureTimesAsArray
  * @param stack
  */
-PIC_INLINE void ImaveVecGetExposureTimesAsArray(ImageVec &stack, std::vector<float> &output, bool bLog)
+PIC_INLINE void ImageVecGetExposureTimesAsArray(ImageVec &stack, std::vector<float> &output, bool bLog)
 {
     output.clear();
 


### PR DESCRIPTION
ImageVecSortByExposureTime and ImageVecGetExposureTimesAsArray where erroneus called "ImaveVecSortByExposureTime" and "ImaveVecGetExposureTimesAsArray". I fixed the typo in the definitions and in all the files where they were called.
