### PR TITLE
changed call of streampos

### DIFF
--- a/include/util/raw.hpp
+++ b/include/util/raw.hpp
@@ -92,7 +92,7 @@ public:
 
         //Calculate length of the file
         file.seekg(0, std::ios::end);
-        std::ios::streampos length = file.tellg();
+        std::streampos length = file.tellg();
         file.seekg(0, std::ios::beg);
 
         if(nData < 1) {


### PR DESCRIPTION
in C++11 streampos is called with std::ios::streampos, in C++17 it has been changed to std::streampos, so I modified where streampos is called to make the library compile in C++17.