### PR TITLE
fix bug in while-loop condition in histogram ceiling

### DIFF
--- a/include/histogram.hpp
+++ b/include/histogram.hpp
@@ -363,10 +363,6 @@ public:
      */
     void ceiling(float k)
     {
-        // reference:
-        // G. W. Larson, H. Rushmeier and C. Piatko, "A visibility matching tone reproduction operator for high dynamic range scenes,"
-        // in IEEE Transactions on Visualization and Computer Graphics, vol. 3, no. 4, pp. 291-306, Oct.-Dec. 1997, doi: 10.1109/2945.646233.
-
         float tolerance = float(Array<uint>::sum(bin, nBin)) * 0.025f;
         int   trimmings = tolerance + 1.0f; // to make sure trimmings (as int) > tolerance (as float) when first enter the while loop
         bool  bFlag = true;
@@ -374,8 +370,6 @@ public:
         std::vector<bool> trimmed_vec;
 
         while((trimmings > tolerance) && bFlag) {
-            // the pseudo code of histogram_ceiling() from the reference paper says that adaptively update T and ceiling
-            // until trimming <= tolerance.
             trimmings = 0;
             float T = float(Array<uint>::sum(bin, nBin));
 

--- a/include/histogram.hpp
+++ b/include/histogram.hpp
@@ -363,13 +363,19 @@ public:
      */
     void ceiling(float k)
     {
+        // reference:
+        // G. W. Larson, H. Rushmeier and C. Piatko, "A visibility matching tone reproduction operator for high dynamic range scenes,"
+        // in IEEE Transactions on Visualization and Computer Graphics, vol. 3, no. 4, pp. 291-306, Oct.-Dec. 1997, doi: 10.1109/2945.646233.
+
         float tolerance = float(Array<uint>::sum(bin, nBin)) * 0.025f;
-        int   trimmings = 0;
+        int   trimmings = tolerance + 1.0f; // to make sure trimmings (as int) > tolerance (as float) when first enter the while loop
         bool  bFlag = true;
 
         std::vector<bool> trimmed_vec;
 
-        while((trimmings <= tolerance) && bFlag) {
+        while((trimmings > tolerance) && bFlag) {
+            // the pseudo code of histogram_ceiling() from the reference paper says that adaptively update T and ceiling
+            // until trimming <= tolerance.
             trimmings = 0;
             float T = float(Array<uint>::sum(bin, nBin));
 


### PR DESCRIPTION
[larson1997.pdf](https://github.com/cnr-isti-vclab/piccante/files/15095464/larson1997.pdf)

the pseudo code of histogram_ceiling() from the reference paper says that adaptively update T and ceiling until trimmings <= tolerance.

thus, the loop condition should be "trimmings > tolerance" and init value of trimmings should > tolerance.